### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/PSOpenLocationCode/security/code-scanning/1](https://github.com/hsaito/PSOpenLocationCode/security/code-scanning/1)

The best way to fix this issue is to explicitly specify a `permissions` block at the workflow level or for the specific job. In this case, since none of the steps in the workflow require write access (they only perform code checkout, restore/build/test), the minimal required permission is `contents: read`. This can be set at the root level of the workflow YAML, right below the `name:` key, to apply it to all jobs within the workflow. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
